### PR TITLE
Fix Measurement Location

### DIFF
--- a/app/controllers/observations_controller.rb
+++ b/app/controllers/observations_controller.rb
@@ -41,6 +41,7 @@ class ObservationsController < ApplicationController
 
   def update
     authorize @observation
+
     respond_to do |format|
       if @observation.update(observation_params)
         format.html { redirect_to @observation, notice: 'Observation was successfully updated.' }
@@ -113,7 +114,7 @@ class ObservationsController < ApplicationController
                                 :notes,
                                 :validation_type_id,
                                 :longhurst_province_id,
-                                location_attributes: [:name, :lat, :lon],
+                                location_attributes: [ :id, :name, :lat, :lon],
     ],
     )
   end

--- a/app/models/measurement.rb
+++ b/app/models/measurement.rb
@@ -19,6 +19,10 @@ class Measurement < ApplicationRecord
   private
 
   def find_or_create_location
-    self.location = Location.find_or_create_by name: location.name
+    unless self.location.persisted?
+      require 'byebug'; byebug
+      self.location = Location.find_or_create_by name: location.name,
+        lat: location.lat, lon: location.lon
+    end
   end
 end


### PR DESCRIPTION
Without the permitted `:id` each update of the observation (and it's attached measurements) would create a new location.