### PR TITLE
Trait form improvements

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -45,7 +45,8 @@ function runSelect2 (klass) {
           results: _.map(data, function(el) {
             return {
               id: el.id,
-              name: el.name
+              name: el.name,
+              description: el.description
             };
           })
         };
@@ -56,8 +57,15 @@ function runSelect2 (klass) {
       return markup;
     },
     minimumInputLength: 2,
-    templateResult: function(item) {
-      return item.name;
+    templateResult: function(e) {
+      if (e.name === undefined) {
+        return "<em>loading</em>"
+      } else {
+        let description = e.description === null ? "" : " - " + e.description
+        return $(
+          '<span>' + e.name + description + '</span>'
+        )
+      }
     },
     templateSelection: function(item) {
       return item.name;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -28,3 +28,7 @@
 .select2-selection__arrow {
   height: 35px !important;
 }
+
+.has-icons-left .select2-selection__rendered {
+  padding-left: 2.5em !important;
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -16,8 +16,11 @@
  */
 
 // ensure select2 inputs are the same height as other inputs
+.selection--single .select2-selection__rendered {
+  line-height: 36px !important;
+}
 .select2-selection__rendered {
-  line-height: 31px !important;
+  line-height: 36px !important;
 }
 .select2-container .select2-selection--single {
   height: 36px !important;

--- a/app/controllers/references_controller.rb
+++ b/app/controllers/references_controller.rb
@@ -32,16 +32,24 @@ class ReferencesController < PreAuthController
   end
 
   def show
-    @reference = Reference.includes(observations: [
-        :species,
-        measurements: [:standard, :value_type, :location, :trait]
-      ],
-      trends: [
-        :species, :location, :standard,
-        :trend_observations
-      ]).find params[:id]
-    @observations = @reference.observations
-    @trends = @reference.trends
+    respond_to do |format|
+      format.html do
+        @reference = Reference.includes(observations: [
+          :species,
+          measurements: [:standard, :value_type, :location, :trait]
+        ],
+        trends: [
+          :species, :location, :standard,
+          :trend_observations
+        ]).find params[:id]
+        @observations = @reference.observations
+        @trends = @reference.trends
+      end
+
+      format.js do
+        @reference = Reference.find params[:id]
+      end
+    end
   end
 
   private

--- a/app/views/observations/_measurement_fields.html.erb
+++ b/app/views/observations/_measurement_fields.html.erb
@@ -9,24 +9,43 @@
       </div>
 
       <div class="field">
-        <%= f.label :trait, class: 'label' %>
-        <%= f.grouped_collection_select(:trait_id, @trait_classes, :traits, :name, :id, :name, {:prompt => 'Select Trait'}, style: 'width: 100%') %>
+        <%= f.label :trait_class, class: 'label' %>
+        <p class="control has-icons-left">
+          <%= f.collection_select(:trait_class_id, @trait_classes, :id, :name, {:prompt => 'Select Trait Class'}, style: 'width: 100%') %>
+          <span class="icon is-small is-left">
+            <i class="fas fa-exclamation"></i>
+          </span>
+        </p>
       </div>
 
-      <%# TODO: show trait class when trait is selected %>
-      <%# <div class="field"> %>
-      <%#   <%= f.label :trait_class, class: 'label' %1> %>
-      <%#   <%= f.collection_select(:trait_class_id, @trait_classes, :id, :name, {:prompt => 'Select Trait Class'}, style: 'width: 100%') %1> %>
-      <%# </div> %>
+      <div class="field">
+        <%= f.label :trait, class: 'label' %>
+        <p class="control has-icons-left">
+          <%= f.grouped_collection_select(:trait_id, @trait_classes, :traits, :name, :id, :name, {:prompt => 'Select Trait'}, style: 'width: 100%', class: 'trait-class-relative') %>
+          <span class="icon is-small is-left">
+            <i class="fas fa-exclamation"></i>
+          </span>
+        </p>
+      </div>
 
       <div class="field">
         <%= f.label :sex_type, class: 'label' %>
-        <%= f.collection_select(:sex_type_id, @sex_types, :id, :name, {:prompt => 'Select Sex'}, style: 'width: 100%') %>
+        <p class="control has-icons-left">
+          <%= f.collection_select(:sex_type_id, @sex_types, :id, :name, {:prompt => 'Select Sex'}, style: 'width: 100%') %>
+          <span class="icon is-small is-left">
+            <i class="fas fa-exclamation"></i>
+          </span>
+        </p>
       </div>
 
       <div class="field">
         <%= f.label :standard, class: 'label' %>
-        <%= f.collection_select(:standard_id, @standards, :id, :name, {:prompt => 'Select Standard'}, style: 'width: 100%') %>
+        <p class="control has-icons-left">
+          <%= f.collection_select(:standard_id, @standards, :id, :name, {:prompt => 'Select Standard'}, style: 'width: 100%', class: 'trait-class-relative') %>
+          <span class="icon is-small is-left">
+            <i class="fas fa-exclamation"></i>
+          </span>
+        </p>
       </div>
 
       <div class="field">
@@ -82,7 +101,12 @@
 
       <div class="field">
         <%= f.label :value, class: 'label' %>
-        <%= f.text_field :value, class: 'input' %><br />
+        <p class="control has-icons-left">
+          <%= f.text_field :value, class: 'input' %><br />
+          <span class="icon is-small is-left">
+            <i class="fas fa-exclamation"></i>
+          </span>
+        </p>
       </div>
 
       <div class="field">

--- a/app/views/observations/_measurement_fields.html.erb
+++ b/app/views/observations/_measurement_fields.html.erb
@@ -11,7 +11,7 @@
       <div class="field">
         <%= f.label :trait_class, class: 'label' %>
         <p class="control has-icons-left">
-          <%= f.collection_select(:trait_class_id, @trait_classes, :id, :name, {:prompt => 'Select Trait Class'}, style: 'width: 100%') %>
+          <%= f.collection_select(:trait_class_id, @trait_classes, :id, :name, {:prompt => 'Select Trait Class'}, style: 'width: 100%', class: 'independent') %>
           <span class="icon is-small is-left">
             <i class="fas fa-exclamation"></i>
           </span>
@@ -31,7 +31,7 @@
       <div class="field">
         <%= f.label :sex_type, class: 'label' %>
         <p class="control has-icons-left">
-          <%= f.collection_select(:sex_type_id, @sex_types, :id, :name, {:prompt => 'Select Sex'}, style: 'width: 100%') %>
+          <%= f.collection_select(:sex_type_id, @sex_types, :id, :name, {:prompt => 'Select Sex'}, style: 'width: 100%', class: 'independent') %>
           <span class="icon is-small is-left">
             <i class="fas fa-exclamation"></i>
           </span>
@@ -41,7 +41,7 @@
       <div class="field">
         <%= f.label :standard, class: 'label' %>
         <p class="control has-icons-left">
-          <%= f.collection_select(:standard_id, @standards, :id, :name, {:prompt => 'Select Standard'}, style: 'width: 100%', class: 'trait-class-relative') %>
+          <%= f.grouped_collection_select(:standard_id, @trait_classes, :standards, :name, :id, :name, {:prompt => 'Select Standard'}, style: 'width: 100%', class: 'trait-class-relative') %>
           <span class="icon is-small is-left">
             <i class="fas fa-exclamation"></i>
           </span>
@@ -50,12 +50,12 @@
 
       <div class="field">
         <%= f.label :measurement_method, class: 'label' %>
-        <%= f.grouped_collection_select(:measurement_method_id, @trait_classes, :measurement_methods, :name, :id, :name, {:prompt => 'Select Measurement Method'}, style: 'width: 100%') %>
+        <%= f.grouped_collection_select(:measurement_method_id, @trait_classes, :measurement_methods, :name, :id, :name, {:prompt => 'Select Measurement Method'}, style: 'width: 100%', class: 'trait-class-relative') %>
       </div>
 
       <div class="field">
         <%= f.label :measurement_model, class: 'label' %>
-        <%= f.grouped_collection_select(:measurement_model_id, @trait_classes, :measurement_models, :name, :id, :name, {:prompt => 'Select Measurement Model'}, style: 'width: 100%') %>
+        <%= f.grouped_collection_select(:measurement_model_id, @trait_classes, :measurement_models, :name, :id, :name, {:prompt => 'Select Measurement Model'}, style: 'width: 100%', class: 'trait-class-relative') %>
       </div>
 
       <%= f.fields_for :location do |fl| %>
@@ -89,14 +89,14 @@
 
       <div class="field">
         <%= f.label :longhurst_province, class: 'label' %>
-        <%= f.collection_select(:longhurst_province_id, @longhurst_provinces, :id, :name, {:prompt => 'Select Longhurst Province'}, style: 'width: 100%') %>
+        <%= f.collection_select(:longhurst_province_id, @longhurst_provinces, :id, :name, {:prompt => 'Select Longhurst Province'}, style: 'width: 100%', class: 'independent') %>
       </div>
     </div>
 
     <div class="column">
       <div class="field">
         <%= f.label :value_type, class: 'label' %>
-        <%= f.collection_select(:value_type_id, @value_types, :id, :name, {:prompt => 'Select Value Type'}, style: 'width: 100%') %>
+        <%= f.collection_select(:value_type_id, @value_types, :id, :name, {:prompt => 'Select Value Type'}, style: 'width: 100%', class: 'independent') %>
       </div>
 
       <div class="field">
@@ -111,7 +111,7 @@
 
       <div class="field">
         <%= f.label :precision_type, class: 'label' %>
-        <%= f.collection_select(:precision_type_id, @precision_types, :id, :name, {:prompt => 'Select Precision Type'}, style: 'width: 100%') %>
+        <%= f.collection_select(:precision_type_id, @precision_types, :id, :name, {:prompt => 'Select Precision Type'}, style: 'width: 100%', class: 'independent') %>
       </div>
 
       <div class="columns">
@@ -172,5 +172,23 @@
 </fieldset>
 
 <script type="text/javascript">
-  $('fieldset.measurement select').select2({ selectOnClose: true });
+
+  $('fieldset.measurement select.independent').select2({ selectOnClose: true });
+
+  $('fieldset.measurement select.trait-class-relative').select2({
+    selectOnClose: true,
+    matcher: function(params, data) {
+      let traitClassId = $(data.element.parentElement).attr("id").match(/(.*_\d+_)/)[0]
+        + "trait_class_id";
+
+      let traitClass = $("#" + traitClassId + " " + "option:selected").text();
+
+      if (data.text.indexOf(traitClass) > -1) {
+        return data;
+      } else {
+        return null;
+      }
+    }
+  });
+
 </script>

--- a/app/views/references/_detail.html.erb
+++ b/app/views/references/_detail.html.erb
@@ -34,5 +34,11 @@
         <td id="reference-file"><%= link_to @reference.reference_file.filename, url_for(@reference.reference_file), target: '_blank' %></td>
       </tr>
     <% end %>
+    <tr>
+      <th>data entered</th>
+      <td id="observations">
+        <%= !reference.observations.blank? %>
+      </td>
+    </tr>
   </tbody>
 </table>

--- a/app/views/search/autocomplete.json.jbuilder
+++ b/app/views/search/autocomplete.json.jbuilder
@@ -1,4 +1,5 @@
 json.array! @items do |item|
   json.id item.id
   json.name item.name
+  json.description item.try(:description) || item.try(:reference)
 end

--- a/app/views/shared/_form_reference.html.erb
+++ b/app/views/shared/_form_reference.html.erb
@@ -3,7 +3,12 @@
 <div class="columns">
   <div class="column">
     <div class="field">
-      <%= select_tag "#{target}[reference#{many ? '_ids' : '_id' }]", nil, style: 'width: 100%', multiple: many %>
+      <p class="control has-icons-left">
+        <%= select_tag "#{target}[reference#{many ? '_ids' : '_id' }]", nil, style: 'width: 100%', multiple: many %>
+        <span class="icon is-small is-left">
+          <i class="fas fa-exclamation"></i>
+        </span>
+      </p>
     </div>
 
     <p class="">

--- a/app/views/shared/_form_species.html.erb
+++ b/app/views/shared/_form_species.html.erb
@@ -4,7 +4,12 @@
   <div class="columns">
     <div class="column">
       <div class="field">
-        <%= select_tag "#{target}[species_id]", nil, style: 'width: 100%' %>
+        <p class="control has-icons-left">
+          <%= select_tag "#{target}[species_id]", nil, style: 'width: 100%' %>
+          <span class="icon is-small is-left">
+            <i class="fas fa-exclamation"></i>
+          </span>
+        </p>
       </div>
     </div>
     <div class="column">


### PR DESCRIPTION
Related to #67 

1) Mark required fields with a `!`
2) add a row to the references preview table stating if we already have observations in the database
3) add hierarchy filter to the dropdown input fields (Trait Class -> Trait / ..)
   <img width="689" alt="Screenshot 2019-11-17 21 07 45" src="https://user-images.githubusercontent.com/205556/69019531-09e94300-097f-11ea-958f-39dc67ec5e01.png">
4) Fix line height of autocomplete fields
