### PR TITLE
Fix species detail page & API

### DIFF
--- a/app/controllers/api/v1/species_controller.rb
+++ b/app/controllers/api/v1/species_controller.rb
@@ -34,7 +34,8 @@ module API::V1
     private
 
     def jsonapi_include
-      super & ["observations", "observations.measurements", "trends", "trends.trend_observations"]
+      super & ["observations", "observations.measurements", "measurements",
+        "trends", "trends.trend_observations"]
     end
 
     def jsonapi_meta(resources)

--- a/app/controllers/species_controller.rb
+++ b/app/controllers/species_controller.rb
@@ -24,7 +24,7 @@ class SpeciesController < PreAuthController
     observations = @species.observations
       .joins(:import)
       .where('imports.aasm_state': "imported")
-    @grouped_measurements = Measurement.where(observation: observations)
+    @grouped_measurements = Measurement.where(observation: observations, species: @species)
       .group_by(&:trait_class)
     @trends = @species.trends
     @group_trends = @species.group_trends

--- a/app/serializers/measurement_serializer.rb
+++ b/app/serializers/measurement_serializer.rb
@@ -1,4 +1,6 @@
 class MeasurementSerializer < BaseSerializer
+  belongs_to :species
+
   attributes :value
   attribute :sex_type do |object|
     object.sex_type&.name

--- a/app/serializers/observation_serializer.rb
+++ b/app/serializers/observation_serializer.rb
@@ -7,5 +7,5 @@ class ObservationSerializer < BaseSerializer
 
   has_many :measurements
 
-  belongs_to :species
+  has_many :species
 end

--- a/app/serializers/species_serializer.rb
+++ b/app/serializers/species_serializer.rb
@@ -3,14 +3,7 @@ class SpeciesSerializer < BaseSerializer
 
   attributes :edge_scientific_name, :iucn_code, :authorship
 
-  # :family, :order, :subclass, :superorder
-
-  # belongs_to :species_superorder
-  # belongs_to :species_data_type
-  # belongs_to :species_subclass
-  # belongs_to :species_order
-  # belongs_to :species_family
-
   has_many :observations
+  has_many :measurements
   has_many :trends
 end

--- a/app/views/pages/api.html.erb
+++ b/app/views/pages/api.html.erb
@@ -66,7 +66,59 @@ $ curl -s -H 'Authorization: Token <%= current_user.token %>' \
       "iucn_code": null,
       "authorship": "Didier 2002 "
     },
-    "relationships": {}
+    "relationships": {
+      "observations": {
+        "data": [
+          {
+            "id": "387",
+            "type": "observation"
+          },
+          {
+            "id": "387",
+            "type": "observation"
+          },
+          {
+            "id": "387",
+            "type": "observation"
+          },
+          {
+            "id": "387",
+            "type": "observation"
+          },
+          {
+            "id": "387",
+            "type": "observation"
+          }
+        ]
+      },
+      "measurements": {
+        "data": [
+          {
+            "id": "4936",
+            "type": "measurement"
+          },
+          {
+            "id": "4937",
+            "type": "measurement"
+          },
+          {
+            "id": "4938",
+            "type": "measurement"
+          },
+          {
+            "id": "4941",
+            "type": "measurement"
+          },
+          {
+            "id": "4942",
+            "type": "measurement"
+          }
+        ]
+      },
+      "trends": {
+        "data": []
+      }
+    }
   },
   "links": {
     "self": "https://www.sharkipedia.org/api/v1/species/9"
@@ -79,7 +131,7 @@ $ curl -s -H 'Authorization: Token <%= current_user.token %>' \
 
 <pre>
 $ curl -s -H 'Authorization: Token <%= current_user.token %>' \
-             "https://www.sharkipedia.org/api/v1/species/9?include=observations,observations.measurements" | jq '.'
+             "https://www.sharkipedia.org/api/v1/species/9?include=observations,measurements" | jq '.'
 {
   "data": {
     "id": "9",
@@ -94,8 +146,48 @@ $ curl -s -H 'Authorization: Token <%= current_user.token %>' \
       "observations": {
         "data": [
           {
-            "id": "52",
+            "id": "387",
             "type": "observation"
+          },
+          {
+            "id": "387",
+            "type": "observation"
+          },
+          {
+            "id": "387",
+            "type": "observation"
+          },
+          {
+            "id": "387",
+            "type": "observation"
+          },
+          {
+            "id": "387",
+            "type": "observation"
+          }
+        ]
+      },
+      "measurements": {
+        "data": [
+          {
+            "id": "4936",
+            "type": "measurement"
+          },
+          {
+            "id": "4937",
+            "type": "measurement"
+          },
+          {
+            "id": "4938",
+            "type": "measurement"
+          },
+          {
+            "id": "4941",
+            "type": "measurement"
+          },
+          {
+            "id": "4942",
+            "type": "measurement"
           }
         ]
       },
@@ -105,11 +197,114 @@ $ curl -s -H 'Authorization: Token <%= current_user.token %>' \
     }
   },
   "links": {
-    "self": "https://www.sharkipedia.org/api/v1/species/9?include=observations,observations.measurements"
+    "self": "https://www.sharkipedia.org/api/v1/species/9?include=observations,measurements"
   },
   "included": [
     {
-      "id": "605",
+      "id": "387",
+      "type": "observation",
+      "attributes": {
+        "depth": "400-1800",
+        "references": [
+          "didier2002a"
+        ]
+      },
+      "relationships": {
+        "measurements": {
+          "data": [
+            {
+              "id": "4936",
+              "type": "measurement"
+            },
+            {
+              "id": "4937",
+              "type": "measurement"
+            },
+            {
+              "id": "4938",
+              "type": "measurement"
+            },
+            {
+              "id": "4939",
+              "type": "measurement"
+            },
+            {
+              "id": "4940",
+              "type": "measurement"
+            },
+            {
+              "id": "4941",
+              "type": "measurement"
+            },
+            {
+              "id": "4942",
+              "type": "measurement"
+            },
+            {
+              "id": "4943",
+              "type": "measurement"
+            },
+            {
+              "id": "4944",
+              "type": "measurement"
+            }
+          ]
+        },
+        "species": {
+          "data": [
+            {
+              "id": "9",
+              "type": "species"
+            },
+            {
+              "id": "23",
+              "type": "species"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "4936",
+      "type": "measurement",
+      "attributes": {
+        "value": "89",
+        "sex_type": "Female",
+        "trait_class": "Length",
+        "trait": "Lmax-observed",
+        "standard": "cm BDL",
+        "measurement_method": null,
+        "measurement_model": null,
+        "value_type": "max",
+        "precision": null,
+        "precision_type": null,
+        "precision_upper": null,
+        "sample_size": 9,
+        "dubious": null,
+        "validated": null,
+        "notes": "TASM",
+        "validation_type": null,
+        "location": "SW of Veryan Bank, Chatham Rise",
+        "ocean": "SW of Veryan Bank, Chatham Rise",
+        "longhurst_province": "New Zealand coast"
+      },
+      "relationships": {
+        "species": {
+          "data": {
+            "id": "9",
+            "type": "species"
+          }
+        },
+        "observation": {
+          "data": {
+            "id": "387",
+            "type": "observation"
+          }
+        }
+      }
+    },
+    {
+      "id": "4937",
       "type": "measurement",
       "attributes": {
         "value": "77.9",
@@ -117,8 +312,8 @@ $ curl -s -H 'Authorization: Token <%= current_user.token %>' \
         "trait_class": "Length",
         "trait": "Lmax-observed",
         "standard": "cm BDL",
-        "measurement_method": "Directly observed",
-        "measurement_model": "Observational",
+        "measurement_method": null,
+        "measurement_model": null,
         "value_type": "max",
         "precision": null,
         "precision_type": null,
@@ -133,16 +328,22 @@ $ curl -s -H 'Authorization: Token <%= current_user.token %>' \
         "longhurst_province": "New Zealand coast"
       },
       "relationships": {
+        "species": {
+          "data": {
+            "id": "9",
+            "type": "species"
+          }
+        },
         "observation": {
           "data": {
-            "id": "52",
+            "id": "387",
             "type": "observation"
           }
         }
       }
     },
     {
-      "id": "606",
+      "id": "4938",
       "type": "measurement",
       "attributes": {
         "value": "60",
@@ -150,8 +351,8 @@ $ curl -s -H 'Authorization: Token <%= current_user.token %>' \
         "trait_class": "Length",
         "trait": "Length at first maturity",
         "standard": "cm BDL",
-        "measurement_method": "Directly observed",
-        "measurement_model": "Observational",
+        "measurement_method": null,
+        "measurement_model": null,
         "value_type": "min",
         "precision": null,
         "precision_type": "range",
@@ -166,16 +367,22 @@ $ curl -s -H 'Authorization: Token <%= current_user.token %>' \
         "longhurst_province": "New Zealand coast"
       },
       "relationships": {
+        "species": {
+          "data": {
+            "id": "9",
+            "type": "species"
+          }
+        },
         "observation": {
           "data": {
-            "id": "52",
+            "id": "387",
             "type": "observation"
           }
         }
       }
     },
     {
-      "id": "609",
+      "id": "4941",
       "type": "measurement",
       "attributes": {
         "value": "142",
@@ -183,8 +390,8 @@ $ curl -s -H 'Authorization: Token <%= current_user.token %>' \
         "trait_class": "Length",
         "trait": "Lmax-observed",
         "standard": "cm TL",
-        "measurement_method": "Directly observed",
-        "measurement_model": "Observational",
+        "measurement_method": null,
+        "measurement_model": null,
         "value_type": "max",
         "precision": null,
         "precision_type": null,
@@ -199,16 +406,22 @@ $ curl -s -H 'Authorization: Token <%= current_user.token %>' \
         "longhurst_province": "New Zealand coast"
       },
       "relationships": {
+        "species": {
+          "data": {
+            "id": "9",
+            "type": "species"
+          }
+        },
         "observation": {
           "data": {
-            "id": "52",
+            "id": "387",
             "type": "observation"
           }
         }
       }
     },
     {
-      "id": "610",
+      "id": "4942",
       "type": "measurement",
       "attributes": {
         "value": "125.1",
@@ -216,8 +429,8 @@ $ curl -s -H 'Authorization: Token <%= current_user.token %>' \
         "trait_class": "Length",
         "trait": "Lmax-observed",
         "standard": "cm TL",
-        "measurement_method": "Directly observed",
-        "measurement_model": "Observational",
+        "measurement_method": null,
+        "measurement_model": null,
         "value_type": "max",
         "precision": null,
         "precision_type": null,
@@ -232,233 +445,16 @@ $ curl -s -H 'Authorization: Token <%= current_user.token %>' \
         "longhurst_province": "New Zealand coast"
       },
       "relationships": {
-        "observation": {
-          "data": {
-            "id": "52",
-            "type": "observation"
-          }
-        }
-      }
-    },
-    {
-      "id": "612",
-      "type": "measurement",
-      "attributes": {
-        "value": "86.7",
-        "sex_type": "Male",
-        "trait_class": "Length",
-        "trait": "Lmax-observed",
-        "standard": "cm TL",
-        "measurement_method": "Directly observed",
-        "measurement_model": "Observational",
-        "value_type": "max",
-        "precision": null,
-        "precision_type": null,
-        "precision_upper": null,
-        "sample_size": 10,
-        "dubious": null,
-        "validated": null,
-        "notes": null,
-        "validation_type": null,
-        "location": "N of Mernoo Bank",
-        "ocean": "N of Mernoo Bank",
-        "longhurst_province": "New Zealand coast"
-      },
-      "relationships": {
-        "observation": {
-          "data": {
-            "id": "52",
-            "type": "observation"
-          }
-        }
-      }
-    },
-    {
-      "id": "611",
-      "type": "measurement",
-      "attributes": {
-        "value": "111.5",
-        "sex_type": "Female",
-        "trait_class": "Length",
-        "trait": "Lmax-observed",
-        "standard": "cm TL",
-        "measurement_method": "Directly observed",
-        "measurement_model": "Observational",
-        "value_type": "max",
-        "precision": null,
-        "precision_type": null,
-        "precision_upper": null,
-        "sample_size": 8,
-        "dubious": null,
-        "validated": null,
-        "notes": null,
-        "validation_type": null,
-        "location": "N of Mernoo Bank",
-        "ocean": "N of Mernoo Bank",
-        "longhurst_province": "New Zealand coast"
-      },
-      "relationships": {
-        "observation": {
-          "data": {
-            "id": "52",
-            "type": "observation"
-          }
-        }
-      }
-    },
-    {
-      "id": "608",
-      "type": "measurement",
-      "attributes": {
-        "value": "42.5",
-        "sex_type": "Male",
-        "trait_class": "Length",
-        "trait": "Lmax-observed",
-        "standard": "cm BDL",
-        "measurement_method": "Directly observed",
-        "measurement_model": "Observational",
-        "value_type": "max",
-        "precision": null,
-        "precision_type": null,
-        "precision_upper": null,
-        "sample_size": 10,
-        "dubious": null,
-        "validated": null,
-        "notes": null,
-        "validation_type": null,
-        "location": "N of Mernoo Bank",
-        "ocean": "N of Mernoo Bank",
-        "longhurst_province": "New Zealand coast"
-      },
-      "relationships": {
-        "observation": {
-          "data": {
-            "id": "52",
-            "type": "observation"
-          }
-        }
-      }
-    },
-    {
-      "id": "607",
-      "type": "measurement",
-      "attributes": {
-        "value": "57.2",
-        "sex_type": "Female",
-        "trait_class": "Length",
-        "trait": "Lmax-observed",
-        "standard": "cm BDL",
-        "measurement_method": "Directly observed",
-        "measurement_model": "Observational",
-        "value_type": "max",
-        "precision": null,
-        "precision_type": null,
-        "precision_upper": null,
-        "sample_size": 8,
-        "dubious": null,
-        "validated": null,
-        "notes": null,
-        "validation_type": null,
-        "location": "N of Mernoo Bank",
-        "ocean": "N of Mernoo Bank",
-        "longhurst_province": "New Zealand coast"
-      },
-      "relationships": {
-        "observation": {
-          "data": {
-            "id": "52",
-            "type": "observation"
-          }
-        }
-      }
-    },
-    {
-      "id": "604",
-      "type": "measurement",
-      "attributes": {
-        "value": "89",
-        "sex_type": "Female",
-        "trait_class": "Length",
-        "trait": "Lmax-observed",
-        "standard": "cm BDL",
-        "measurement_method": "Directly observed",
-        "measurement_model": "Observational",
-        "value_type": "max",
-        "precision": null,
-        "precision_type": null,
-        "precision_upper": null,
-        "sample_size": 9,
-        "dubious": null,
-        "validated": null,
-        "notes": "TASM",
-        "validation_type": null,
-        "location": "SW of Veryan Bank, Chatham Rise",
-        "ocean": "SW of Veryan Bank, Chatham Rise",
-        "longhurst_province": "New Zealand coast"
-      },
-      "relationships": {
-        "observation": {
-          "data": {
-            "id": "52",
-            "type": "observation"
-          }
-        }
-      }
-    },
-    {
-      "id": "52",
-      "type": "observation",
-      "attributes": {
-        "depth": "400-1800",
-        "references": [
-          "didier2002a"
-        ]
-      },
-      "relationships": {
-        "measurements": {
-          "data": [
-            {
-              "id": "605",
-              "type": "measurement"
-            },
-            {
-              "id": "606",
-              "type": "measurement"
-            },
-            {
-              "id": "609",
-              "type": "measurement"
-            },
-            {
-              "id": "610",
-              "type": "measurement"
-            },
-            {
-              "id": "612",
-              "type": "measurement"
-            },
-            {
-              "id": "611",
-              "type": "measurement"
-            },
-            {
-              "id": "608",
-              "type": "measurement"
-            },
-            {
-              "id": "607",
-              "type": "measurement"
-            },
-            {
-              "id": "604",
-              "type": "measurement"
-            }
-          ]
-        },
         "species": {
           "data": {
             "id": "9",
             "type": "species"
+          }
+        },
+        "observation": {
+          "data": {
+            "id": "387",
+            "type": "observation"
           }
         }
       }
@@ -471,41 +467,130 @@ $ curl -s -H 'Authorization: Token <%= current_user.token %>' \
 
 <pre>
 $ curl -s -H 'Authorization: Token <%= current_user.token %>' \
-             "https://www.sharkipedia.org/api/v1/species/acroteriobatus-annulatus?include=trends,trends.trend_observations" | jq '.'
+             "https://www.sharkipedia.org/api/v1/species/aetobatus-narinari?include=trends,trends.trend_observations" | jq '.'
 {
   "data": {
-    "id": "562",
+    "id": "158",
     "type": "species",
     "attributes": {
-      "binomial_name": "Acroteriobatus annulatus",
-      "edge_scientific_name": "Acroteriobatus annulatus",
+      "binomial_name": "Aetobatus narinari",
+      "edge_scientific_name": "Aetobatus narinari",
       "iucn_code": null,
-      "authorship": "Müller & Henle 1841 "
+      "authorship": "White & Naylor 2017"
     },
     "relationships": {
       "observations": {
-        "data": []
+        "data": [
+          {
+            "id": "481",
+            "type": "observation"
+          },
+          {
+            "id": "481",
+            "type": "observation"
+          },
+          {
+            "id": "481",
+            "type": "observation"
+          },
+          {
+            "id": "481",
+            "type": "observation"
+          },
+          {
+            "id": "481",
+            "type": "observation"
+          },
+          {
+            "id": "481",
+            "type": "observation"
+          },
+          {
+            "id": "481",
+            "type": "observation"
+          },
+          {
+            "id": "481",
+            "type": "observation"
+          },
+          {
+            "id": "481",
+            "type": "observation"
+          },
+          {
+            "id": "481",
+            "type": "observation"
+          },
+          {
+            "id": "481",
+            "type": "observation"
+          },
+          {
+            "id": "481",
+            "type": "observation"
+          }
+        ]
+      },
+      "measurements": {
+        "data": [
+          {
+            "id": "6138",
+            "type": "measurement"
+          },
+          {
+            "id": "6139",
+            "type": "measurement"
+          },
+          {
+            "id": "6140",
+            "type": "measurement"
+          },
+          {
+            "id": "6141",
+            "type": "measurement"
+          },
+          {
+            "id": "6142",
+            "type": "measurement"
+          },
+          {
+            "id": "6143",
+            "type": "measurement"
+          },
+          {
+            "id": "6144",
+            "type": "measurement"
+          },
+          {
+            "id": "6145",
+            "type": "measurement"
+          },
+          {
+            "id": "6146",
+            "type": "measurement"
+          },
+          {
+            "id": "6147",
+            "type": "measurement"
+          },
+          {
+            "id": "6148",
+            "type": "measurement"
+          },
+          {
+            "id": "6149",
+            "type": "measurement"
+          }
+        ]
       },
       "trends": {
         "data": [
           {
-            "id": "1818",
+            "id": "1",
             "type": "trend"
           },
           {
-            "id": "1819",
-            "type": "trend"
-          },
-          {
-            "id": "1820",
-            "type": "trend"
-          },
-          {
-            "id": "1821",
-            "type": "trend"
-          },
-          {
-            "id": "1822",
+            "id": "2",
             "type": "trend"
           }
         ]
@@ -513,1085 +598,257 @@ $ curl -s -H 'Authorization: Token <%= current_user.token %>' \
     }
   },
   "links": {
-    "self": "https://www.sharkipedia.org/api/v1/species/acroteriobatus-annulatus?include=trends,trends.trend_observations"
+    "self": "https://www.sharkipedia.org/api/v1/species/aetobatus-narinari?include=trends,trends.trend_observations"
   },
   "included": [
     {
-      "id": "36916",
-      "type": "trend_observation",
-      "attributes": {
-        "year": "1991",
-        "value": "2775.215478981"
-      },
-      "relationships": {
-        "trend": {
-          "data": {
-            "id": "1818",
-            "type": "trend"
-          }
-        }
-      }
-    },
-    {
-      "id": "36917",
-      "type": "trend_observation",
-      "attributes": {
-        "year": "1992",
-        "value": "2722.02573665366"
-      },
-      "relationships": {
-        "trend": {
-          "data": {
-            "id": "1818",
-            "type": "trend"
-          }
-        }
-      }
-    },
-    {
-      "id": "36918",
-      "type": "trend_observation",
-      "attributes": {
-        "year": "1993",
-        "value": "2882.34305704685"
-      },
-      "relationships": {
-        "trend": {
-          "data": {
-            "id": "1818",
-            "type": "trend"
-          }
-        }
-      }
-    },
-    {
-      "id": "36919",
-      "type": "trend_observation",
-      "attributes": {
-        "year": "1994",
-        "value": "3567.94378273346"
-      },
-      "relationships": {
-        "trend": {
-          "data": {
-            "id": "1818",
-            "type": "trend"
-          }
-        }
-      }
-    },
-    {
-      "id": "36920",
-      "type": "trend_observation",
-      "attributes": {
-        "year": "1995",
-        "value": "1508.42688527218"
-      },
-      "relationships": {
-        "trend": {
-          "data": {
-            "id": "1818",
-            "type": "trend"
-          }
-        }
-      }
-    },
-    {
-      "id": "36921",
-      "type": "trend_observation",
-      "attributes": {
-        "year": "1996",
-        "value": "1203.13386715965"
-      },
-      "relationships": {
-        "trend": {
-          "data": {
-            "id": "1818",
-            "type": "trend"
-          }
-        }
-      }
-    },
-    {
-      "id": "36922",
-      "type": "trend_observation",
-      "attributes": {
-        "year": "1997",
-        "value": "978.247254997898"
-      },
-      "relationships": {
-        "trend": {
-          "data": {
-            "id": "1818",
-            "type": "trend"
-          }
-        }
-      }
-    },
-    {
-      "id": "36923",
-      "type": "trend_observation",
-      "attributes": {
-        "year": "1999",
-        "value": "1303.13740794073"
-      },
-      "relationships": {
-        "trend": {
-          "data": {
-            "id": "1818",
-            "type": "trend"
-          }
-        }
-      }
-    },
-    {
-      "id": "36924",
-      "type": "trend_observation",
-      "attributes": {
-        "year": "2003",
-        "value": "679.15265628679"
-      },
-      "relationships": {
-        "trend": {
-          "data": {
-            "id": "1818",
-            "type": "trend"
-          }
-        }
-      }
-    },
-    {
-      "id": "36925",
-      "type": "trend_observation",
-      "attributes": {
-        "year": "2006",
-        "value": "787.267676504215"
-      },
-      "relationships": {
-        "trend": {
-          "data": {
-            "id": "1818",
-            "type": "trend"
-          }
-        }
-      }
-    },
-    {
-      "id": "36926",
-      "type": "trend_observation",
-      "attributes": {
-        "year": "2010",
-        "value": "223.186581153005"
-      },
-      "relationships": {
-        "trend": {
-          "data": {
-            "id": "1818",
-            "type": "trend"
-          }
-        }
-      }
-    },
-    {
-      "id": "1818",
-      "type": "trend",
-      "attributes": {
-        "location": "south coast of South Africa",
-        "data_type": "sCPUE",
-        "sampling_method": "trawl",
-        "no_years": 20,
-        "time_min": null,
-        "comments": "trawl surveys commenced in 1984, IUCN Red List only considered the period from 1991 onwards due to improvements in chondrichthyan identification following the initial survey years",
-        "page_and_figure_number": "NA",
-        "line_used": "NA",
-        "pdf_page": null,
-        "actual_page": null,
-        "depth": null,
-        "figure_name": null,
-        "figure_data": null,
-        "reference": "Winkerunpubl",
-        "standard": "kg",
-        "start_year": 1991,
-        "end_year": 2010,
-        "species_group": null,
-        "unit_freeform": "",
-        "sampling_method_info": "demersal, autumn, old gear",
-        "dataset_representativeness_experts": "South Africa",
-        "experts_for_representativeness": "IUCN Sub-Equatorial Africa sharks and rays - South Africa 2018",
-        "dataset_map": false,
-        "variance": true,
-        "data_mined": false,
-        "unit_time": null,
-        "unit_spatial": "square_nautical_mile_area_swept",
-        "unit_gear": null,
-        "unit_transformation": null,
-        "analysis_model": "delta_geoGLMM",
-        "oceans": [
-          "Atlantic",
-          "Indian"
-        ]
-      },
-      "relationships": {
-        "species": {
-          "data": {
-            "id": "562",
-            "type": "species"
-          }
-        },
-        "trend_observations": {
-          "data": [
-            {
-              "id": "36916",
-              "type": "trend_observation"
-            },
-            {
-              "id": "36917",
-              "type": "trend_observation"
-            },
-            {
-              "id": "36918",
-              "type": "trend_observation"
-            },
-            {
-              "id": "36919",
-              "type": "trend_observation"
-            },
-            {
-              "id": "36920",
-              "type": "trend_observation"
-            },
-            {
-              "id": "36921",
-              "type": "trend_observation"
-            },
-            {
-              "id": "36922",
-              "type": "trend_observation"
-            },
-            {
-              "id": "36923",
-              "type": "trend_observation"
-            },
-            {
-              "id": "36924",
-              "type": "trend_observation"
-            },
-            {
-              "id": "36925",
-              "type": "trend_observation"
-            },
-            {
-              "id": "36926",
-              "type": "trend_observation"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "id": "36927",
-      "type": "trend_observation",
-      "attributes": {
-        "year": "2004",
-        "value": "177.24733152935"
-      },
-      "relationships": {
-        "trend": {
-          "data": {
-            "id": "1819",
-            "type": "trend"
-          }
-        }
-      }
-    },
-    {
-      "id": "36928",
-      "type": "trend_observation",
-      "attributes": {
-        "year": "2005",
-        "value": "47.4558611288131"
-      },
-      "relationships": {
-        "trend": {
-          "data": {
-            "id": "1819",
-            "type": "trend"
-          }
-        }
-      }
-    },
-    {
-      "id": "36929",
-      "type": "trend_observation",
-      "attributes": {
-        "year": "2007",
-        "value": "72.9481963477065"
-      },
-      "relationships": {
-        "trend": {
-          "data": {
-            "id": "1819",
-            "type": "trend"
-          }
-        }
-      }
-    },
-    {
-      "id": "36930",
-      "type": "trend_observation",
-      "attributes": {
-        "year": "2008",
-        "value": "123.876758027821"
-      },
-      "relationships": {
-        "trend": {
-          "data": {
-            "id": "1819",
-            "type": "trend"
-          }
-        }
-      }
-    },
-    {
-      "id": "36931",
-      "type": "trend_observation",
-      "attributes": {
-        "year": "2009",
-        "value": "190.061790115181"
-      },
-      "relationships": {
-        "trend": {
-          "data": {
-            "id": "1819",
-            "type": "trend"
-          }
-        }
-      }
-    },
-    {
-      "id": "36932",
-      "type": "trend_observation",
-      "attributes": {
-        "year": "2011",
-        "value": "864.117279706905"
-      },
-      "relationships": {
-        "trend": {
-          "data": {
-            "id": "1819",
-            "type": "trend"
-          }
-        }
-      }
-    },
-    {
-      "id": "36933",
-      "type": "trend_observation",
-      "attributes": {
-        "year": "2014",
-        "value": "346.414701274951"
-      },
-      "relationships": {
-        "trend": {
-          "data": {
-            "id": "1819",
-            "type": "trend"
-          }
-        }
-      }
-    },
-    {
-      "id": "36934",
-      "type": "trend_observation",
-      "attributes": {
-        "year": "2015",
-        "value": "359.048890958407"
-      },
-      "relationships": {
-        "trend": {
-          "data": {
-            "id": "1819",
-            "type": "trend"
-          }
-        }
-      }
-    },
-    {
-      "id": "36935",
-      "type": "trend_observation",
-      "attributes": {
-        "year": "2016",
-        "value": "557.340280272092"
-      },
-      "relationships": {
-        "trend": {
-          "data": {
-            "id": "1819",
-            "type": "trend"
-          }
-        }
-      }
-    },
-    {
-      "id": "1819",
-      "type": "trend",
-      "attributes": {
-        "location": "south coast of South Africa",
-        "data_type": "sCPUE",
-        "sampling_method": "trawl",
-        "no_years": 13,
-        "time_min": null,
-        "comments": "trawl surveys commenced in 1984, IUCN Red List only considered the period from 1991 onwards due to improvements in chondrichthyan identification following the initial survey years",
-        "page_and_figure_number": "NA",
-        "line_used": "NA",
-        "pdf_page": null,
-        "actual_page": null,
-        "depth": null,
-        "figure_name": null,
-        "figure_data": null,
-        "reference": "Winkerunpubl",
-        "standard": "kg",
-        "start_year": 2004,
-        "end_year": 2016,
-        "species_group": null,
-        "unit_freeform": "",
-        "sampling_method_info": "demersal, autumn, new gear",
-        "dataset_representativeness_experts": "South Africa",
-        "experts_for_representativeness": "IUCN Sub-Equatorial Africa sharks and rays - South Africa 2018",
-        "dataset_map": false,
-        "variance": true,
-        "data_mined": false,
-        "unit_time": null,
-        "unit_spatial": "square_nautical_mile_area_swept",
-        "unit_gear": null,
-        "unit_transformation": null,
-        "analysis_model": "delta_geoGLMM",
-        "oceans": [
-          "Atlantic",
-          "Indian"
-        ]
-      },
-      "relationships": {
-        "species": {
-          "data": {
-            "id": "562",
-            "type": "species"
-          }
-        },
-        "trend_observations": {
-          "data": [
-            {
-              "id": "36927",
-              "type": "trend_observation"
-            },
-            {
-              "id": "36928",
-              "type": "trend_observation"
-            },
-            {
-              "id": "36929",
-              "type": "trend_observation"
-            },
-            {
-              "id": "36930",
-              "type": "trend_observation"
-            },
-            {
-              "id": "36931",
-              "type": "trend_observation"
-            },
-            {
-              "id": "36932",
-              "type": "trend_observation"
-            },
-            {
-              "id": "36933",
-              "type": "trend_observation"
-            },
-            {
-              "id": "36934",
-              "type": "trend_observation"
-            },
-            {
-              "id": "36935",
-              "type": "trend_observation"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "id": "36936",
-      "type": "trend_observation",
-      "attributes": {
-        "year": "2001",
-        "value": "1944.87751583194"
-      },
-      "relationships": {
-        "trend": {
-          "data": {
-            "id": "1820",
-            "type": "trend"
-          }
-        }
-      }
-    },
-    {
-      "id": "36937",
-      "type": "trend_observation",
-      "attributes": {
-        "year": "2006",
-        "value": "901.869646841857"
-      },
-      "relationships": {
-        "trend": {
-          "data": {
-            "id": "1820",
-            "type": "trend"
-          }
-        }
-      }
-    },
-    {
-      "id": "1820",
-      "type": "trend",
-      "attributes": {
-        "location": "south coast of South Africa",
-        "data_type": "sCPUE",
-        "sampling_method": "trawl",
-        "no_years": 6,
-        "time_min": null,
-        "comments": "trawl surveys commenced in 1984, IUCN Red List only considered the period from 1991 onwards due to improvements in chondrichthyan identification following the initial survey years",
-        "page_and_figure_number": "NA",
-        "line_used": "NA",
-        "pdf_page": null,
-        "actual_page": null,
-        "depth": null,
-        "figure_name": null,
-        "figure_data": null,
-        "reference": "Winkerunpubl",
-        "standard": "kg",
-        "start_year": 2001,
-        "end_year": 2006,
-        "species_group": null,
-        "unit_freeform": "",
-        "sampling_method_info": "demersal, spring, old gear",
-        "dataset_representativeness_experts": "South Africa",
-        "experts_for_representativeness": "IUCN Sub-Equatorial Africa sharks and rays - South Africa 2018",
-        "dataset_map": false,
-        "variance": true,
-        "data_mined": false,
-        "unit_time": null,
-        "unit_spatial": "square_nautical_mile_area_swept",
-        "unit_gear": null,
-        "unit_transformation": null,
-        "analysis_model": "delta_geoGLMM",
-        "oceans": [
-          "Atlantic",
-          "Indian"
-        ]
-      },
-      "relationships": {
-        "species": {
-          "data": {
-            "id": "562",
-            "type": "species"
-          }
-        },
-        "trend_observations": {
-          "data": [
-            {
-              "id": "36936",
-              "type": "trend_observation"
-            },
-            {
-              "id": "36937",
-              "type": "trend_observation"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "id": "36938",
-      "type": "trend_observation",
-      "attributes": {
-        "year": "2003",
-        "value": "951.193384724797"
-      },
-      "relationships": {
-        "trend": {
-          "data": {
-            "id": "1821",
-            "type": "trend"
-          }
-        }
-      }
-    },
-    {
-      "id": "36939",
-      "type": "trend_observation",
-      "attributes": {
-        "year": "2004",
-        "value": "674.835902861578"
-      },
-      "relationships": {
-        "trend": {
-          "data": {
-            "id": "1821",
-            "type": "trend"
-          }
-        }
-      }
-    },
-    {
-      "id": "36940",
-      "type": "trend_observation",
-      "attributes": {
-        "year": "2007",
-        "value": "1075.91967922498"
-      },
-      "relationships": {
-        "trend": {
-          "data": {
-            "id": "1821",
-            "type": "trend"
-          }
-        }
-      }
-    },
-    {
-      "id": "36941",
-      "type": "trend_observation",
-      "attributes": {
-        "year": "2008",
-        "value": "1117.42397857322"
-      },
-      "relationships": {
-        "trend": {
-          "data": {
-            "id": "1821",
-            "type": "trend"
-          }
-        }
-      }
-    },
-    {
-      "id": "36942",
-      "type": "trend_observation",
-      "attributes": {
-        "year": "2016",
-        "value": "326.962485347036"
-      },
-      "relationships": {
-        "trend": {
-          "data": {
-            "id": "1821",
-            "type": "trend"
-          }
-        }
-      }
-    },
-    {
-      "id": "1821",
-      "type": "trend",
-      "attributes": {
-        "location": "south coast of South Africa",
-        "data_type": "sCPUE",
-        "sampling_method": "trawl",
-        "no_years": 14,
-        "time_min": null,
-        "comments": "trawl surveys commenced in 1984, IUCN Red List only considered the period from 1991 onwards due to improvements in chondrichthyan identification following the initial survey years",
-        "page_and_figure_number": "NA",
-        "line_used": "NA",
-        "pdf_page": null,
-        "actual_page": null,
-        "depth": null,
-        "figure_name": null,
-        "figure_data": null,
-        "reference": "Winkerunpubl",
-        "standard": "kg",
-        "start_year": 2003,
-        "end_year": 2016,
-        "species_group": null,
-        "unit_freeform": "",
-        "sampling_method_info": "demersal, spring, new gear",
-        "dataset_representativeness_experts": "South Africa",
-        "experts_for_representativeness": "IUCN Sub-Equatorial Africa sharks and rays - South Africa 2018",
-        "dataset_map": false,
-        "variance": true,
-        "data_mined": false,
-        "unit_time": null,
-        "unit_spatial": "square_nautical_mile_area_swept",
-        "unit_gear": null,
-        "unit_transformation": null,
-        "analysis_model": "delta_geoGLMM",
-        "oceans": [
-          "Atlantic",
-          "Indian"
-        ]
-      },
-      "relationships": {
-        "species": {
-          "data": {
-            "id": "562",
-            "type": "species"
-          }
-        },
-        "trend_observations": {
-          "data": [
-            {
-              "id": "36938",
-              "type": "trend_observation"
-            },
-            {
-              "id": "36939",
-              "type": "trend_observation"
-            },
-            {
-              "id": "36940",
-              "type": "trend_observation"
-            },
-            {
-              "id": "36941",
-              "type": "trend_observation"
-            },
-            {
-              "id": "36942",
-              "type": "trend_observation"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "id": "36943",
-      "type": "trend_observation",
-      "attributes": {
-        "year": "1998",
-        "value": "3.34214804815134"
-      },
-      "relationships": {
-        "trend": {
-          "data": {
-            "id": "1822",
-            "type": "trend"
-          }
-        }
-      }
-    },
-    {
-      "id": "36944",
-      "type": "trend_observation",
-      "attributes": {
-        "year": "1999",
-        "value": "4.4637862034953"
-      },
-      "relationships": {
-        "trend": {
-          "data": {
-            "id": "1822",
-            "type": "trend"
-          }
-        }
-      }
-    },
-    {
-      "id": "36945",
+      "id": "73157",
       "type": "trend_observation",
       "attributes": {
         "year": "2000",
-        "value": "2.48466117213693"
+        "value": "5.041"
       },
       "relationships": {
         "trend": {
           "data": {
-            "id": "1822",
+            "id": "1",
             "type": "trend"
           }
         }
       }
     },
     {
-      "id": "36946",
+      "id": "73158",
       "type": "trend_observation",
       "attributes": {
         "year": "2001",
-        "value": "4.95144621063543"
+        "value": "4.263"
       },
       "relationships": {
         "trend": {
           "data": {
-            "id": "1822",
+            "id": "1",
             "type": "trend"
           }
         }
       }
     },
     {
-      "id": "36947",
+      "id": "73159",
       "type": "trend_observation",
       "attributes": {
         "year": "2002",
-        "value": "4.60890718828081"
+        "value": "1.045"
       },
       "relationships": {
         "trend": {
           "data": {
-            "id": "1822",
+            "id": "1",
             "type": "trend"
           }
         }
       }
     },
     {
-      "id": "36948",
+      "id": "73160",
       "type": "trend_observation",
       "attributes": {
         "year": "2003",
-        "value": "3.94431057359786"
+        "value": "4.527"
       },
       "relationships": {
         "trend": {
           "data": {
-            "id": "1822",
+            "id": "1",
             "type": "trend"
           }
         }
       }
     },
     {
-      "id": "36949",
+      "id": "73161",
       "type": "trend_observation",
       "attributes": {
         "year": "2004",
-        "value": "5.6086783269951"
+        "value": "1.253"
       },
       "relationships": {
         "trend": {
           "data": {
-            "id": "1822",
+            "id": "1",
             "type": "trend"
           }
         }
       }
     },
     {
-      "id": "36950",
+      "id": "73162",
       "type": "trend_observation",
       "attributes": {
         "year": "2005",
-        "value": "3.51212399470004"
+        "value": "2.331"
       },
       "relationships": {
         "trend": {
           "data": {
-            "id": "1822",
+            "id": "1",
             "type": "trend"
           }
         }
       }
     },
     {
-      "id": "36951",
+      "id": "73163",
       "type": "trend_observation",
       "attributes": {
         "year": "2006",
-        "value": "4.16194231308653"
+        "value": "1.553"
       },
       "relationships": {
         "trend": {
           "data": {
-            "id": "1822",
+            "id": "1",
             "type": "trend"
           }
         }
       }
     },
     {
-      "id": "36952",
+      "id": "73164",
       "type": "trend_observation",
       "attributes": {
         "year": "2007",
-        "value": "3.01909607061774"
+        "value": "9.341"
       },
       "relationships": {
         "trend": {
           "data": {
-            "id": "1822",
+            "id": "1",
             "type": "trend"
           }
         }
       }
     },
     {
-      "id": "36953",
+      "id": "73165",
       "type": "trend_observation",
       "attributes": {
         "year": "2008",
-        "value": "9.75405773803405"
+        "value": "1.169"
       },
       "relationships": {
         "trend": {
           "data": {
-            "id": "1822",
+            "id": "1",
             "type": "trend"
           }
         }
       }
     },
     {
-      "id": "36954",
+      "id": "73166",
       "type": "trend_observation",
       "attributes": {
         "year": "2009",
-        "value": "3.19470430993294"
+        "value": "6.27"
       },
       "relationships": {
         "trend": {
           "data": {
-            "id": "1822",
+            "id": "1",
             "type": "trend"
           }
         }
       }
     },
     {
-      "id": "36955",
+      "id": "73167",
       "type": "trend_observation",
       "attributes": {
         "year": "2010",
-        "value": "3.77919644191187"
+        "value": "1.135"
       },
       "relationships": {
         "trend": {
           "data": {
-            "id": "1822",
+            "id": "1",
             "type": "trend"
           }
         }
       }
     },
     {
-      "id": "36956",
+      "id": "73168",
       "type": "trend_observation",
       "attributes": {
         "year": "2011",
-        "value": "3.94260085173281"
+        "value": "1.897"
       },
       "relationships": {
         "trend": {
           "data": {
-            "id": "1822",
+            "id": "1",
             "type": "trend"
           }
         }
       }
     },
     {
-      "id": "36957",
+      "id": "73169",
       "type": "trend_observation",
       "attributes": {
         "year": "2012",
-        "value": "5.42379275262669"
+        "value": "2.521"
       },
       "relationships": {
         "trend": {
           "data": {
-            "id": "1822",
+            "id": "1",
             "type": "trend"
           }
         }
       }
     },
     {
-      "id": "36958",
+      "id": "73170",
       "type": "trend_observation",
       "attributes": {
         "year": "2013",
-        "value": "2.62715163323554"
+        "value": "1.925"
       },
       "relationships": {
         "trend": {
           "data": {
-            "id": "1822",
+            "id": "1",
             "type": "trend"
           }
         }
       }
     },
     {
-      "id": "36959",
+      "id": "73171",
       "type": "trend_observation",
       "attributes": {
         "year": "2014",
-        "value": "5.55307200712719"
+        "value": "6.685"
       },
       "relationships": {
         "trend": {
           "data": {
-            "id": "1822",
+            "id": "1",
             "type": "trend"
           }
         }
       }
     },
     {
-      "id": "36960",
-      "type": "trend_observation",
-      "attributes": {
-        "year": "2015",
-        "value": "4.01653482019453"
-      },
-      "relationships": {
-        "trend": {
-          "data": {
-            "id": "1822",
-            "type": "trend"
-          }
-        }
-      }
-    },
-    {
-      "id": "36961",
-      "type": "trend_observation",
-      "attributes": {
-        "year": "2016",
-        "value": "5.8526346514081"
-      },
-      "relationships": {
-        "trend": {
-          "data": {
-            "id": "1822",
-            "type": "trend"
-          }
-        }
-      }
-    },
-    {
-      "id": "36962",
-      "type": "trend_observation",
-      "attributes": {
-        "year": "2017",
-        "value": "4.4674674236987"
-      },
-      "relationships": {
-        "trend": {
-          "data": {
-            "id": "1822",
-            "type": "trend"
-          }
-        }
-      }
-    },
-    {
-      "id": "1822",
+      "id": "1",
       "type": "trend",
       "attributes": {
-        "location": "de Hoop Marine Protected Area, south coast of South Africa",
-        "data_type": "sCPUE",
-        "sampling_method": "line",
-        "no_years": 20,
+        "location": "Mexican coastal waters (Atlantic)",
+        "data_type": "biomass",
+        "sampling_method": "landings",
+        "no_years": 15,
         "time_min": null,
         "comments": null,
         "page_and_figure_number": "NA",
@@ -1601,115 +858,305 @@ $ curl -s -H 'Authorization: Token <%= current_user.token %>' \
         "depth": null,
         "figure_name": null,
         "figure_data": null,
-        "reference": "Winkerunpubl",
-        "standard": "individual",
-        "start_year": 1998,
-        "end_year": 2017,
+        "reference": "Pérezunpubl1",
+        "standard": "ton",
+        "start_year": 2000,
+        "end_year": 2014,
         "species_group": null,
         "unit_freeform": "",
-        "sampling_method_info": "shore-based angling",
-        "dataset_representativeness_experts": "South Africa",
-        "experts_for_representativeness": "IUCN Sub-Equatorial Africa sharks and rays - South Africa 2018",
+        "sampling_method_info": "NA",
+        "dataset_representativeness_experts": "west gulf of Mexico",
+        "experts_for_representativeness": "IUCN NWAtlantic sharks and rays - Bahamas June 2019",
         "dataset_map": false,
-        "variance": true,
+        "variance": false,
         "data_mined": false,
         "unit_time": null,
         "unit_spatial": null,
-        "unit_gear": "angler",
+        "unit_gear": null,
         "unit_transformation": null,
-        "analysis_model": "GLM",
+        "analysis_model": null,
         "oceans": [
-          "Atlantic",
-          "Indian"
+          "Atlantic"
         ]
       },
       "relationships": {
         "species": {
           "data": {
-            "id": "562",
+            "id": "158",
             "type": "species"
           }
         },
         "trend_observations": {
           "data": [
             {
-              "id": "36943",
+              "id": "73157",
               "type": "trend_observation"
             },
             {
-              "id": "36944",
+              "id": "73158",
               "type": "trend_observation"
             },
             {
-              "id": "36945",
+              "id": "73159",
               "type": "trend_observation"
             },
             {
-              "id": "36946",
+              "id": "73160",
               "type": "trend_observation"
             },
             {
-              "id": "36947",
+              "id": "73161",
               "type": "trend_observation"
             },
             {
-              "id": "36948",
+              "id": "73162",
               "type": "trend_observation"
             },
             {
-              "id": "36949",
+              "id": "73163",
               "type": "trend_observation"
             },
             {
-              "id": "36950",
+              "id": "73164",
               "type": "trend_observation"
             },
             {
-              "id": "36951",
+              "id": "73165",
               "type": "trend_observation"
             },
             {
-              "id": "36952",
+              "id": "73166",
               "type": "trend_observation"
             },
             {
-              "id": "36953",
+              "id": "73167",
               "type": "trend_observation"
             },
             {
-              "id": "36954",
+              "id": "73168",
               "type": "trend_observation"
             },
             {
-              "id": "36955",
+              "id": "73169",
               "type": "trend_observation"
             },
             {
-              "id": "36956",
+              "id": "73170",
               "type": "trend_observation"
             },
             {
-              "id": "36957",
+              "id": "73171",
+              "type": "trend_observation"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "73172",
+      "type": "trend_observation",
+      "attributes": {
+        "year": "2009",
+        "value": "0.166666667"
+      },
+      "relationships": {
+        "trend": {
+          "data": {
+            "id": "2",
+            "type": "trend"
+          }
+        }
+      }
+    },
+    {
+      "id": "73173",
+      "type": "trend_observation",
+      "attributes": {
+        "year": "2010",
+        "value": "0.137254902"
+      },
+      "relationships": {
+        "trend": {
+          "data": {
+            "id": "2",
+            "type": "trend"
+          }
+        }
+      }
+    },
+    {
+      "id": "73174",
+      "type": "trend_observation",
+      "attributes": {
+        "year": "2011",
+        "value": "0.176470588"
+      },
+      "relationships": {
+        "trend": {
+          "data": {
+            "id": "2",
+            "type": "trend"
+          }
+        }
+      }
+    },
+    {
+      "id": "73175",
+      "type": "trend_observation",
+      "attributes": {
+        "year": "2012",
+        "value": "0.054054054"
+      },
+      "relationships": {
+        "trend": {
+          "data": {
+            "id": "2",
+            "type": "trend"
+          }
+        }
+      }
+    },
+    {
+      "id": "73176",
+      "type": "trend_observation",
+      "attributes": {
+        "year": "2013",
+        "value": "0.225806452"
+      },
+      "relationships": {
+        "trend": {
+          "data": {
+            "id": "2",
+            "type": "trend"
+          }
+        }
+      }
+    },
+    {
+      "id": "73177",
+      "type": "trend_observation",
+      "attributes": {
+        "year": "2016",
+        "value": "0.421052632"
+      },
+      "relationships": {
+        "trend": {
+          "data": {
+            "id": "2",
+            "type": "trend"
+          }
+        }
+      }
+    },
+    {
+      "id": "73178",
+      "type": "trend_observation",
+      "attributes": {
+        "year": "2017",
+        "value": "0.222222222"
+      },
+      "relationships": {
+        "trend": {
+          "data": {
+            "id": "2",
+            "type": "trend"
+          }
+        }
+      }
+    },
+    {
+      "id": "73179",
+      "type": "trend_observation",
+      "attributes": {
+        "year": "2018",
+        "value": "0.233333333"
+      },
+      "relationships": {
+        "trend": {
+          "data": {
+            "id": "2",
+            "type": "trend"
+          }
+        }
+      }
+    },
+    {
+      "id": "2",
+      "type": "trend",
+      "attributes": {
+        "location": "Bélize, Glovers Reef and Southwater Cay",
+        "data_type": "sSPUE",
+        "sampling_method": "sighting",
+        "no_years": 10,
+        "time_min": null,
+        "comments": null,
+        "page_and_figure_number": "NA",
+        "line_used": "NA",
+        "pdf_page": null,
+        "actual_page": null,
+        "depth": null,
+        "figure_name": null,
+        "figure_data": null,
+        "reference": "Clementiunpubl1",
+        "standard": "individual",
+        "start_year": 2009,
+        "end_year": 2018,
+        "species_group": null,
+        "unit_freeform": "mean",
+        "sampling_method_info": "video",
+        "dataset_representativeness_experts": "west Caribbean sea",
+        "experts_for_representativeness": "IUCN NWAtlantic sharks and rays - Bahamas June 2019",
+        "dataset_map": false,
+        "variance": false,
+        "data_mined": false,
+        "unit_time": null,
+        "unit_spatial": null,
+        "unit_gear": "BRUV",
+        "unit_transformation": null,
+        "analysis_model": null,
+        "oceans": [
+          "Atlantic"
+        ]
+      },
+      "relationships": {
+        "species": {
+          "data": {
+            "id": "158",
+            "type": "species"
+          }
+        },
+        "trend_observations": {
+          "data": [
+            {
+              "id": "73172",
               "type": "trend_observation"
             },
             {
-              "id": "36958",
+              "id": "73173",
               "type": "trend_observation"
             },
             {
-              "id": "36959",
+              "id": "73174",
               "type": "trend_observation"
             },
             {
-              "id": "36960",
+              "id": "73175",
               "type": "trend_observation"
             },
             {
-              "id": "36961",
+              "id": "73176",
               "type": "trend_observation"
             },
             {
-              "id": "36962",
+              "id": "73177",
+              "type": "trend_observation"
+            },
+            {
+              "id": "73178",
+              "type": "trend_observation"
+            },
+            {
+              "id": "73179",
               "type": "trend_observation"
             }
           ]
@@ -1737,7 +1184,51 @@ $ curl -s -H 'Authorization: Token <%= current_user.token %>' \
         "iucn_code": null,
         "authorship": "Quaranta, Didier, Long & Ebert 2006 "
       },
-      "relationships": {}
+      "relationships": {
+        "observations": {
+          "data": [
+            {
+              "id": "453",
+              "type": "observation"
+            },
+            {
+              "id": "453",
+              "type": "observation"
+            },
+            {
+              "id": "453",
+              "type": "observation"
+            },
+            {
+              "id": "453",
+              "type": "observation"
+            }
+          ]
+        },
+        "measurements": {
+          "data": [
+            {
+              "id": "5716",
+              "type": "measurement"
+            },
+            {
+              "id": "5717",
+              "type": "measurement"
+            },
+            {
+              "id": "5718",
+              "type": "measurement"
+            },
+            {
+              "id": "5719",
+              "type": "measurement"
+            }
+          ]
+        },
+        "trends": {
+          "data": []
+        }
+      }
     },
     {
       "id": "1271",
@@ -1748,13 +1239,24 @@ $ curl -s -H 'Authorization: Token <%= current_user.token %>' \
         "iucn_code": null,
         "authorship": "Ebert, Straube, Leslie & Weigmann 2016"
       },
-      "relationships": {}
+      "relationships": {
+        "observations": {
+          "data": []
+        },
+        "measurements": {
+          "data": []
+        },
+        "trends": {
+          "data": []
+        }
+      }
     }
   ],
   "meta": {
     "total": 2,
     "pagination": {
-      "current": 1
+      "current": 1,
+      "records": 2
     }
   },
   "links": {


### PR DESCRIPTION
Fixes #292 & #288

#272 introduced:

1. a bug where the species detail page would show all measurements related to an observation that the species is associated with, instead of only the measurements for the species. 😓 
2. didn't reflect the change of the association change in the API. Unfortunately, the resulting fix introduces a breaking change in way measurement data is requested and presented.
