### PR TITLE
Add reference id to details view

### DIFF
--- a/app/views/references/_detail.html.erb
+++ b/app/views/references/_detail.html.erb
@@ -1,6 +1,10 @@
 <table class="table is-bordered is-striped is-narrow is-hoverable is-fullwidth">
   <tbody>
     <tr>
+      <th>ID</th>
+      <td><%= reference.id %></td>
+    </tr>
+    <tr>
       <th>AuthorYear</th>
       <td id="author-year">
         <% if local_assigns.has_key? :render_links %>


### PR DESCRIPTION
The ID of the reference is now visible in the table:

![](https://cldup.com/9zgDly0AlA.png)

Is this sufficient?