### PR TITLE
Admin reference bug

### DIFF
--- a/app/controllers/admin/references_controller.rb
+++ b/app/controllers/admin/references_controller.rb
@@ -11,9 +11,9 @@ module Admin
     # end
 
     # Define a custom finder by overriding the `find_resource` method:
-    # def find_resource(param)
-    #   Reference.find_by!(slug: param)
-    # end
+    def find_resource(slug)
+      Reference.friendly.find(slug)
+    end
 
     # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
     # for more information

--- a/app/controllers/admin/species_controller.rb
+++ b/app/controllers/admin/species_controller.rb
@@ -11,8 +11,8 @@ module Admin
     # end
 
     # Define a custom finder by overriding the `find_resource` method:
-    def find_resource(param)
-      Species.find_by!(slug: param)
+    def find_resource(slug)
+      Species.friendly.find(slug)
     end
 
     # See https://administrate-prototype.herokuapp.com/customizing_controller_actions


### PR DESCRIPTION
For the reference edit bug fix:

Administrate was trying to use ActiveRecord's find using the friendly id slug and consequently failed (error page)
