### PR TITLE
Add observation table (depth and hidden fields) to import view

### DIFF
--- a/app/views/imports/show.html.erb
+++ b/app/views/imports/show.html.erb
@@ -169,7 +169,7 @@
         </div>
       </div>
 
-      <%= render partial: 'observations/details', locals: { species: observation.species, references: observation.references, measurements: observation.measurements } %>
+      <%= render partial: 'observations/details', locals: { species: observation.species, references: observation.references, measurements: observation.measurements, hidden: observation.hidden, depth: observation.depth } %>
 
     <% end %>
   <% end %>

--- a/app/views/observations/_details.html.erb
+++ b/app/views/observations/_details.html.erb
@@ -3,6 +3,19 @@
     <% species.each do |observation_species| %>
       <%= render partial: 'species/detail', locals: { species: observation_species, render_links: true } %>
     <% end %>
+    <h4 class="subtitle is-4">Observation</h4>
+    <table class="table is-bordered is-striped is-narrow is-hoverable is-fullwidth">
+      <tbody>
+        <tr>
+          <th>Depth</th>
+          <td><%= depth %>m</td>
+        </tr>
+        <tr>
+          <th>Hidden</th>
+          <td><%= hidden %></td>
+        </tr>
+      </tbody>
+    </table>
   </div>
   <div class="column">
     <% references.each do |reference| %>

--- a/spec/system/review_trait_measurement_system_spec.rb
+++ b/spec/system/review_trait_measurement_system_spec.rb
@@ -1,0 +1,34 @@
+require "system_helper"
+
+RSpec.describe "Review a trait import" do
+  let!(:species) { create(:species, name: "Carcharhinus acronotus") }
+  let!(:reference) { create(:reference, name: "driggers2004a") }
+
+  let!(:trait) { create(:trait) }
+  let!(:trait_class) { trait.trait_class }
+  let!(:sex_type) { create(:sex_type) }
+  let!(:standard) { create(:standard, trait_class:) }
+  let!(:measurement_method) { create(:measurement_method, trait_class:) }
+  let!(:measurement_model) { create(:measurement_model, trait_class:) }
+  let!(:longhurst_province) { create(:longhurst_province) }
+  let!(:value_type) { create(:value_type) }
+  let!(:precision_type) { create(:precision_type) }
+  let!(:observation) { create(:observation) }
+  let!(:measurement) { create(:measurement, observation:) }
+
+  let(:contributor) { create(:contributor) }
+  let!(:import) { create(:traits_import, xlsx_file: nil, observations: [observation], user: contributor) }
+
+  # Import#notify_admins needs at least one admin
+  let!(:admin) { create(:admin) }
+
+  it "allows users to review trait imports" do
+    sign_in admin
+
+    visit import_path(import)
+
+    expect(page).to have_content(import.title)
+    expect(page).to have_content(observation.depth)
+    expect(page).to have_content(observation.hidden)
+  end
+end


### PR DESCRIPTION
Depth and Hidden fields are now available in the import view:

![image](https://user-images.githubusercontent.com/4411121/206868479-3f084807-8ca8-4282-86f2-dece22757488.png)
