### PR TITLE
Fix off by one error for year in TrendChart.js

### DIFF
--- a/app/javascript/components/TrendChart.js
+++ b/app/javascript/components/TrendChart.js
@@ -3,7 +3,9 @@ import PropTypes from "prop-types"
 import { Line } from 'react-chartjs-2';
 
 const TrendChart = (props) => {
-  const years = props.observations.map(pair => new Date(pair[0]));
+	// In order to produce the correct year in the Date object, we passed it '7' to give it the month of August
+	// making sure that the conversion would be correct regardless of the browsers local timezone
+	const years = props.observations.map((pair) => new Date(pair[0], 7));
 
   const values = props.observations.map(pair => {
     if (pair[1] == "") {


### PR DESCRIPTION
The X-axis in the TrendChard component is now showing the correct year. 

![image](https://user-images.githubusercontent.com/4411121/208250601-ecb579cc-9f82-49f4-b1a2-3cd2b6c5a52f.png)

Fixes #704  


