### PR TITLE
Remove `+ 1` from tooltip label

### DIFF
--- a/app/javascript/components/TrendChart.js
+++ b/app/javascript/components/TrendChart.js
@@ -49,7 +49,7 @@ const TrendChart = (props) => {
     tooltips: {
       callbacks: {
         title: (tooltipItem) => {
-          return new Date(tooltipItem[0].label).getFullYear() + 1;
+          return new Date(tooltipItem[0].label).getFullYear();
         }
       }
     },


### PR DESCRIPTION
Follow up to #743 