### PR TITLE
Add rubocop config (forwarding to standard)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,4 @@
+require: standard
+
+inherit_gem:
+  standard: config/base.yml


### PR DESCRIPTION
https://github.com/testdouble/standard#usage-via-rubocop
> If you only want to use Standard's rules while continuing to use
RuboCop's CLI (for example, to continue using your favorite IDE/tooling/workflow with RuboCop support), you can configure this in your .rubocop.yml